### PR TITLE
'Weight' and 'Dimension' displaying TWICE after reset variation

### DIFF
--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -26,6 +26,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @see woocommerce_default_product_tabs()
  */
+
+add_filter( 'woocommerce_product_tabs', 'custom_remove_product_tabs', 99 );
+function custom_remove_product_tabs( $tabs ) {
+	
+  if ( isset( $tabs['additional_information'] ) ) {
+    unset( $tabs['additional_information'] );
+  }
+  return $tabs;
+}
+
 $product_tabs = apply_filters( 'woocommerce_product_tabs', array() );
 
 if ( ! empty( $product_tabs ) ) : ?>


### PR DESCRIPTION
unset the additional information to prevent double weight and dimension

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The weight and dimension should not displayed twice after reset variation
Reference Issue Report #27635

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:
**Video Bug Reproduce:** https://youtu.be/kHGTjGuaJRI

**Before the changes implemented**

Screenshot:
1. variation not selected yet.
![Capture](https://user-images.githubusercontent.com/42957537/100957796-b9bf2d80-354d-11eb-9a4f-83abc1f0f525.PNG)
2. variation is selected and ready to be reset/clear.
![Capture1](https://user-images.githubusercontent.com/42957537/100958068-38b46600-354e-11eb-909a-0fd267b9ea1f.PNG)
3. variation is reseted/cleared and then the bug happen.
![Capture2](https://user-images.githubusercontent.com/42957537/100959424-cabd6e00-3550-11eb-8843-43f58496b381.PNG)


**After the changes implemented**
1. go to woocommerce/templates/single-product/tabs/tabs.php 
2. write the code to unset the additional information .

add_filter( 'woocommerce_product_tabs', 'custom_remove_product_tabs', 99 );
function custom_remove_product_tabs( $tabs ) {
	
  if ( isset( $tabs['additional_information'] ) ) {
    unset( $tabs['additional_information'] );
  }
  return $tabs;
}

3. after that code implemented, the weight and dimension is not double anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
